### PR TITLE
Environment folders and starring

### DIFF
--- a/CodeStation.xcodeproj/project.pbxproj
+++ b/CodeStation.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A10013 /* HookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10013 /* HookManager.swift */; };
 		A10014 /* PersistenceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10014 /* PersistenceModels.swift */; };
 		A10015 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10015 /* Environment.swift */; };
+		A10040 /* Folder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10040 /* Folder.swift */; };
 		A10017 /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10017 /* BoardView.swift */; };
 		A10018 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10018 /* SidebarView.swift */; };
 		A10019 /* SidebarRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10019 /* SidebarRowView.swift */; };
@@ -44,6 +45,7 @@
 		AT0001 /* SessionStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT0001 /* SessionStatusTests.swift */; };
 		AT0002 /* TerminalSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT0002 /* TerminalSessionTests.swift */; };
 		AT0003 /* EnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT0003 /* EnvironmentTests.swift */; };
+		AT0020 /* FolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT0020 /* FolderTests.swift */; };
 		AT0004 /* NotificationSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT0004 /* NotificationSettingsTests.swift */; };
 		AT0005 /* PromptButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT0005 /* PromptButtonTests.swift */; };
 		AT0006 /* PersistenceModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT0006 /* PersistenceModelsTests.swift */; };
@@ -92,6 +94,7 @@
 		B10013 /* HookManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookManager.swift; sourceTree = "<group>"; };
 		B10014 /* PersistenceModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceModels.swift; sourceTree = "<group>"; };
 		B10015 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		B10040 /* Folder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Folder.swift; sourceTree = "<group>"; };
 		B10017 /* BoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardView.swift; sourceTree = "<group>"; };
 		B10018 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		B10019 /* SidebarRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarRowView.swift; sourceTree = "<group>"; };
@@ -114,6 +117,7 @@
 		BT0001 /* SessionStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStatusTests.swift; sourceTree = "<group>"; };
 		BT0002 /* TerminalSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionTests.swift; sourceTree = "<group>"; };
 		BT0003 /* EnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentTests.swift; sourceTree = "<group>"; };
+		BT0020 /* FolderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderTests.swift; sourceTree = "<group>"; };
 		BT0004 /* NotificationSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsTests.swift; sourceTree = "<group>"; };
 		BT0005 /* PromptButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptButtonTests.swift; sourceTree = "<group>"; };
 		BT0006 /* PersistenceModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceModelsTests.swift; sourceTree = "<group>"; };
@@ -221,6 +225,7 @@
 				B10010 /* SessionStatus.swift */,
 				B10014 /* PersistenceModels.swift */,
 				B10015 /* Environment.swift */,
+				B10040 /* Folder.swift */,
 				B10034 /* NotificationSettings.swift */,
 				B10037 /* PromptButton.swift */,
 			);
@@ -293,6 +298,7 @@
 				BT0001 /* SessionStatusTests.swift */,
 				BT0002 /* TerminalSessionTests.swift */,
 				BT0003 /* EnvironmentTests.swift */,
+				BT0020 /* FolderTests.swift */,
 				BT0004 /* NotificationSettingsTests.swift */,
 				BT0005 /* PromptButtonTests.swift */,
 				BT0006 /* PersistenceModelsTests.swift */,
@@ -434,6 +440,7 @@
 				A10013 /* HookManager.swift in Sources */,
 				A10014 /* PersistenceModels.swift in Sources */,
 				A10015 /* Environment.swift in Sources */,
+				A10040 /* Folder.swift in Sources */,
 				A10017 /* BoardView.swift in Sources */,
 				A10018 /* SidebarView.swift in Sources */,
 				A10019 /* SidebarRowView.swift in Sources */,
@@ -458,6 +465,7 @@
 				AT0001 /* SessionStatusTests.swift in Sources */,
 				AT0002 /* TerminalSessionTests.swift in Sources */,
 				AT0003 /* EnvironmentTests.swift in Sources */,
+				AT0020 /* FolderTests.swift in Sources */,
 				AT0004 /* NotificationSettingsTests.swift in Sources */,
 				AT0005 /* PromptButtonTests.swift in Sources */,
 				AT0006 /* PersistenceModelsTests.swift in Sources */,

--- a/CodeStation/App/ContentView.swift
+++ b/CodeStation/App/ContentView.swift
@@ -121,6 +121,14 @@ struct ContentView: View {
             }
             Button(Strings.Terminals.cancel, role: .cancel) {}
         }
+        .alert(Strings.Environments.newFolder, isPresented: $viewModel.showNewFolderAlert) {
+            TextField(Strings.Environments.folderNamePlaceholder, text: $viewModel.newFolderName)
+            Button(Strings.Environments.create) {
+                let name = viewModel.newFolderName.trimmingCharacters(in: .whitespaces)
+                viewModel.addFolder(name: name.isEmpty ? nil : name)
+            }
+            Button(Strings.Terminals.cancel, role: .cancel) {}
+        }
         .onAppear {
             try? HookManager.install()
         }

--- a/CodeStation/Model/Environment.swift
+++ b/CodeStation/Model/Environment.swift
@@ -5,10 +5,14 @@ class Environment: Identifiable {
     let id: UUID
     var name: String
     var sortOrder: Int
+    var folderID: UUID?
+    var isStarred: Bool
 
-    init(id: UUID = UUID(), name: String, sortOrder: Int) {
+    init(id: UUID = UUID(), name: String, sortOrder: Int, folderID: UUID? = nil, isStarred: Bool = false) {
         self.id = id
         self.name = name
         self.sortOrder = sortOrder
+        self.folderID = folderID
+        self.isStarred = isStarred
     }
 }

--- a/CodeStation/Model/Folder.swift
+++ b/CodeStation/Model/Folder.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+@Observable
+class Folder: Identifiable {
+    let id: UUID
+    var name: String
+    var sortOrder: Int
+    var isExpanded: Bool
+
+    init(id: UUID = UUID(), name: String, sortOrder: Int, isExpanded: Bool = true) {
+        self.id = id
+        self.name = name
+        self.sortOrder = sortOrder
+        self.isExpanded = isExpanded
+    }
+}

--- a/CodeStation/Model/PersistenceModels.swift
+++ b/CodeStation/Model/PersistenceModels.swift
@@ -7,6 +7,14 @@ struct StoreSnapshot: Codable {
     var notificationSettings: NotificationSettings?
     var promptButtons: [PromptButton]?
     var skipCloseConfirmation: Bool?
+    var folders: [FolderSnapshot]?
+}
+
+struct FolderSnapshot: Codable {
+    var id: UUID
+    var name: String
+    var sortOrder: Int
+    var isExpanded: Bool
 }
 
 struct EnvironmentSnapshot: Codable {
@@ -16,6 +24,8 @@ struct EnvironmentSnapshot: Codable {
     var sessions: [SessionSnapshot]
     var columnProportions: [Double]
     var rowProportion: Double
+    var folderID: UUID? = nil
+    var isStarred: Bool? = nil
 }
 
 struct SessionSnapshot: Codable {

--- a/CodeStation/Sidebar/SidebarRowView.swift
+++ b/CodeStation/Sidebar/SidebarRowView.swift
@@ -19,8 +19,8 @@ struct SidebarRowView: View {
 
     var body: some View {
         HStack(spacing: Constants.hStackSpacing) {
-            Image(systemName: Strings.Icons.grid)
-                .foregroundStyle(.secondary)
+            Image(systemName: environment.isStarred ? Strings.Icons.starFill : Strings.Icons.grid)
+                .foregroundStyle(environment.isStarred ? AnyShapeStyle(.yellow) : AnyShapeStyle(.secondary))
                 .font(.system(size: Constants.iconSize))
 
             if isEditing {
@@ -71,9 +71,17 @@ struct SidebarRowView: View {
         }
         .contentShape(Rectangle())
         .contextMenu {
+            Button(environment.isStarred ? Strings.Environments.unstar : Strings.Environments.star) {
+                viewModel.toggleStar(environment)
+            }
             Button(Strings.Environments.rename) {
                 DispatchQueue.main.async {
                     beginRename()
+                }
+            }
+            if environment.folderID != nil {
+                Button(Strings.Environments.moveOutOfFolder) {
+                    viewModel.moveEnvironment(environment, toFolder: nil)
                 }
             }
             Divider()

--- a/CodeStation/Sidebar/SidebarView.swift
+++ b/CodeStation/Sidebar/SidebarView.swift
@@ -9,28 +9,143 @@ struct SidebarView: View {
 
     var body: some View {
         List(selection: $viewModel.selectedEnvironmentID) {
-            ForEach(viewModel.sortedEnvironments) { env in
-                SidebarRowView(environment: env, viewModel: viewModel)
-                    .tag(env.id)
+            ForEach(viewModel.sortedFolders) { folder in
+                SidebarFolderView(folder: folder, viewModel: viewModel)
             }
             .onMove { source, destination in
-                viewModel.moveEnvironment(from: source, to: destination)
+                viewModel.moveFolder(from: source, to: destination)
+            }
+
+            ForEach(viewModel.topLevelEnvironments) { env in
+                SidebarRowView(environment: env, viewModel: viewModel)
+                    .tag(env.id)
+                    .draggable(env.id.uuidString)
+                    .dropDestination(for: String.self) { items, _ in
+                        viewModel.handleEnvironmentDrop(items, before: env)
+                    }
+            }
+            .onMove { source, destination in
+                viewModel.moveEnvironment(from: source, to: destination, inFolder: nil)
             }
         }
         .listStyle(.sidebar)
+        // Dropping anywhere on the sidebar background moves an environment out
+        // to the top level, so an environment can leave a folder even when no
+        // top-level rows exist to drop onto.
+        .dropDestination(for: String.self) { items, _ in
+            viewModel.handleEnvironmentDrop(items, toFolder: nil)
+        }
         .safeAreaInset(edge: .bottom) {
             HStack {
-                Button {
-                    viewModel.newEnvironmentName = ""
-                    viewModel.showNewEnvironmentAlert = true
+                Menu {
+                    Button(Strings.Environments.newEnvironment) {
+                        viewModel.newEnvironmentName = ""
+                        viewModel.showNewEnvironmentAlert = true
+                    }
+                    Button(Strings.Environments.newFolder) {
+                        viewModel.newFolderName = ""
+                        viewModel.showNewFolderAlert = true
+                    }
                 } label: {
-                    Label(Strings.Environments.newEnvironment, systemImage: Strings.Icons.plus)
+                    Label(Strings.Environments.add, systemImage: Strings.Icons.plus)
                 }
-                .buttonStyle(.borderless)
+                .menuStyle(.borderlessButton)
+                .fixedSize()
                 .padding(Constants.buttonPadding)
 
                 Spacer()
             }
         }
+    }
+}
+
+private struct SidebarFolderView: View {
+    private enum Constants {
+        static let iconSize: CGFloat = 12
+        static let spacing: CGFloat = 8
+    }
+
+    let folder: Folder
+    let viewModel: AppViewModel
+
+    @FocusState private var isFieldFocused: Bool
+    @State private var isEditing = false
+    @State private var editedName = ""
+
+    private var isExpanded: Binding<Bool> {
+        Binding(
+            get: { folder.isExpanded },
+            set: { viewModel.setFolderExpanded(folder, expanded: $0) }
+        )
+    }
+
+    var body: some View {
+        DisclosureGroup(isExpanded: isExpanded) {
+            ForEach(viewModel.environments(in: folder)) { env in
+                SidebarRowView(environment: env, viewModel: viewModel)
+                    .tag(env.id)
+                    .draggable(env.id.uuidString)
+                    .dropDestination(for: String.self) { items, _ in
+                        viewModel.handleEnvironmentDrop(items, before: env)
+                    }
+            }
+            .onMove { source, destination in
+                viewModel.moveEnvironment(from: source, to: destination, inFolder: folder.id)
+            }
+        } label: {
+            label
+        }
+    }
+
+    @ViewBuilder
+    private var label: some View {
+        HStack(spacing: Constants.spacing) {
+            Image(systemName: Strings.Icons.folder)
+                .foregroundStyle(.secondary)
+                .font(.system(size: Constants.iconSize))
+
+            if isEditing {
+                TextField(Strings.Environments.folderNamePlaceholder, text: $editedName)
+                    .textFieldStyle(.plain)
+                    .focused($isFieldFocused)
+                    .onSubmit { commitRename() }
+                    .onChange(of: isFieldFocused) { _, focused in
+                        if !focused { commitRename() }
+                    }
+            } else {
+                Text(folder.name)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .dropDestination(for: String.self) { items, _ in
+            viewModel.handleEnvironmentDrop(items, toFolder: folder.id)
+        }
+        .contextMenu {
+            Button(Strings.Environments.renameFolder) {
+                DispatchQueue.main.async { beginRename() }
+            }
+            Divider()
+            Button(Strings.Environments.deleteFolder, role: .destructive) {
+                DispatchQueue.main.async { viewModel.removeFolder(folder) }
+            }
+        }
+    }
+
+    private func beginRename() {
+        editedName = folder.name
+        isEditing = true
+        DispatchQueue.main.async { isFieldFocused = true }
+    }
+
+    private func commitRename() {
+        guard isEditing else { return }
+        let trimmed = editedName.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty {
+            viewModel.renameFolder(folder, to: trimmed)
+        }
+        isEditing = false
     }
 }

--- a/CodeStation/Utilities/Strings.swift
+++ b/CodeStation/Utilities/Strings.swift
@@ -22,6 +22,16 @@ enum Strings {
         static let delete = "Delete"
         static let environmentNamePlaceholder = "Environment name"
         static let create = "Create"
+        static let star = "Star"
+        static let unstar = "Unstar"
+        static let newFolder = "New Folder"
+        static let folderDefaultName = "Folder"
+        static func newFolderName(_ count: Int) -> String { return "Folder \(count)" }
+        static let renameFolder = "Rename Folder"
+        static let deleteFolder = "Delete Folder"
+        static let folderNamePlaceholder = "Folder name"
+        static let moveOutOfFolder = "Move out of folder"
+        static let add = "Add"
     }
 
     // MARK: - Terminals
@@ -92,6 +102,11 @@ enum Strings {
         static let terminal = "terminal"
         static let grid = "square.grid.2x2"
         static let gear = "gearshape"
+        static let star = "star"
+        static let starFill = "star.fill"
+        static let folder = "folder"
+        static let chevronRight = "chevron.right"
+        static let chevronDown = "chevron.down"
     }
 
     // MARK: - Settings

--- a/CodeStation/ViewModels/AppViewModel.swift
+++ b/CodeStation/ViewModels/AppViewModel.swift
@@ -12,6 +12,7 @@ class AppViewModel {
     }
 
     var environments: [Environment] = []
+    var folders: [Folder] = []
     var selectedEnvironmentID: UUID? {
         didSet {
             // Leaving an environment defocuses its terminals so a terminal that
@@ -30,6 +31,8 @@ class AppViewModel {
     var isModalOpen = false
     var showNewEnvironmentAlert = false
     var newEnvironmentName = ""
+    var showNewFolderAlert = false
+    var newFolderName = ""
 
     static let defaultFontSize: CGFloat = Constants.defaultFontSize
     static let minFontSize: CGFloat = Constants.minFontSize
@@ -52,6 +55,30 @@ class AppViewModel {
 
     var sortedEnvironments: [Environment] {
         environments.sorted { $0.sortOrder < $1.sortOrder }
+    }
+
+    var sortedFolders: [Folder] {
+        folders.sorted { $0.sortOrder < $1.sortOrder }
+    }
+
+    var topLevelEnvironments: [Environment] {
+        sortedEnvironments.filter { $0.folderID == nil }
+    }
+
+    func environments(in folder: Folder) -> [Environment] {
+        sortedEnvironments.filter { $0.folderID == folder.id }
+    }
+
+    // Flattened order of environments a user can step through, following the
+    // sidebar layout: each folder's environments (only when the folder is
+    // expanded) then the top-level environments.
+    var visibleEnvironmentsInOrder: [Environment] {
+        var result: [Environment] = []
+        for folder in sortedFolders where folder.isExpanded {
+            result.append(contentsOf: environments(in: folder))
+        }
+        result.append(contentsOf: topLevelEnvironments)
+        return result
     }
 
     init() {
@@ -145,18 +172,115 @@ class AppViewModel {
         scheduleSave()
     }
 
-    func moveEnvironment(from source: IndexSet, to destination: Int) {
-        var sorted = sortedEnvironments
-        sorted.move(fromOffsets: source, toOffset: destination)
-        for (i, env) in sorted.enumerated() {
+    // Reorders environments within a single container (a folder, or the
+    // top level when folderID is nil). sortOrder values stay unique per
+    // container, which is all the sidebar ordering relies on.
+    func moveEnvironment(from source: IndexSet, to destination: Int, inFolder folderID: UUID? = nil) {
+        var container = sortedEnvironments.filter { $0.folderID == folderID }
+        container.move(fromOffsets: source, toOffset: destination)
+        for (i, env) in container.enumerated() {
             env.sortOrder = i
         }
+        scheduleSave()
+    }
+
+    // Moves an environment into a folder (or out to the top level when
+    // folderID is nil), placing it at the end of the destination container.
+    func moveEnvironment(_ env: Environment, toFolder folderID: UUID?) {
+        guard env.folderID != folderID else { return }
+        env.folderID = folderID
+        let siblings = sortedEnvironments.filter { $0.folderID == folderID && $0.id != env.id }
+        env.sortOrder = (siblings.map(\.sortOrder).max() ?? -1) + 1
         scheduleSave()
     }
 
     func renameEnvironment(_ env: Environment, to newName: String) {
         env.name = newName
         scheduleSave()
+    }
+
+    func toggleStar(_ env: Environment) {
+        env.isStarred.toggle()
+        scheduleSave()
+    }
+
+    // MARK: - Folder CRUD
+
+    @discardableResult
+    func addFolder(name: String? = nil) -> Folder {
+        let nextOrder = (folders.map(\.sortOrder).max() ?? -1) + 1
+        let folderName = name ?? Strings.Environments.newFolderName(folders.count + 1)
+        let folder = Folder(name: folderName, sortOrder: nextOrder)
+        folders.append(folder)
+        scheduleSave()
+        return folder
+    }
+
+    // Deleting a folder keeps its environments, moving them back to the top level.
+    func removeFolder(_ folder: Folder) {
+        for env in environments where env.folderID == folder.id {
+            env.folderID = nil
+        }
+        folders.removeAll { $0.id == folder.id }
+        scheduleSave()
+    }
+
+    func renameFolder(_ folder: Folder, to newName: String) {
+        folder.name = newName
+        scheduleSave()
+    }
+
+    func setFolderExpanded(_ folder: Folder, expanded: Bool) {
+        folder.isExpanded = expanded
+        scheduleSave()
+    }
+
+    func moveFolder(from source: IndexSet, to destination: Int) {
+        var sorted = sortedFolders
+        sorted.move(fromOffsets: source, toOffset: destination)
+        for (i, folder) in sorted.enumerated() {
+            folder.sortOrder = i
+        }
+        scheduleSave()
+    }
+
+    // Reorders/moves an environment so it lands immediately before `target`,
+    // adopting the target's container. Used for row-to-row drops.
+    func moveEnvironment(_ dragged: Environment, before target: Environment) {
+        guard dragged.id != target.id else { return }
+        dragged.folderID = target.folderID
+        var container = sortedEnvironments.filter { $0.folderID == target.folderID && $0.id != dragged.id }
+        let targetIndex = container.firstIndex { $0.id == target.id } ?? container.count
+        container.insert(dragged, at: targetIndex)
+        for (i, env) in container.enumerated() {
+            env.sortOrder = i
+        }
+        scheduleSave()
+    }
+
+    func environment(withID id: UUID) -> Environment? {
+        environments.first { $0.id == id }
+    }
+
+    // MARK: - Drag & Drop
+
+    private func draggedEnvironment(from items: [String]) -> Environment? {
+        guard let first = items.first, let id = UUID(uuidString: first) else { return nil }
+        return environment(withID: id)
+    }
+
+    @discardableResult
+    func handleEnvironmentDrop(_ items: [String], before target: Environment) -> Bool {
+        guard let dragged = draggedEnvironment(from: items) else { return false }
+        moveEnvironment(dragged, before: target)
+        return true
+    }
+
+    @discardableResult
+    func handleEnvironmentDrop(_ items: [String], toFolder folderID: UUID?) -> Bool {
+        guard let dragged = draggedEnvironment(from: items) else { return false }
+        moveEnvironment(dragged, toFolder: folderID)
+        return true
     }
 
     // MARK: - Board ViewModels
@@ -222,7 +346,7 @@ class AppViewModel {
     }
 
     func focusEnvironmentUp() {
-        let sorted = sortedEnvironments
+        let sorted = visibleEnvironmentsInOrder
         guard !sorted.isEmpty else { return }
         let currentIndex = sorted.firstIndex(where: { $0.id == selectedEnvironmentID }) ?? 0
         let targetIndex = currentIndex == 0 ? sorted.count - 1 : currentIndex - 1
@@ -231,7 +355,7 @@ class AppViewModel {
     }
 
     func focusEnvironmentDown() {
-        let sorted = sortedEnvironments
+        let sorted = visibleEnvironmentsInOrder
         guard !sorted.isEmpty else { return }
         let currentIndex = sorted.firstIndex(where: { $0.id == selectedEnvironmentID }) ?? 0
         let targetIndex = currentIndex == sorted.count - 1 ? 0 : currentIndex + 1
@@ -346,14 +470,24 @@ class AppViewModel {
                     sortOrder: env.sortOrder,
                     sessions: sessionSnapshots,
                     columnProportions: (boardVM?.columnProportions ?? []).map { Double($0) },
-                    rowProportion: Double(boardVM?.rowProportion ?? 0.5)
+                    rowProportion: Double(boardVM?.rowProportion ?? 0.5),
+                    folderID: env.folderID,
+                    isStarred: env.isStarred
                 )
             },
             selectedEnvironmentID: selectedEnvironmentID,
             fontSize: Double(fontSize),
             notificationSettings: notificationSettings,
             promptButtons: promptButtons,
-            skipCloseConfirmation: skipCloseConfirmation
+            skipCloseConfirmation: skipCloseConfirmation,
+            folders: sortedFolders.map { folder in
+                FolderSnapshot(
+                    id: folder.id,
+                    name: folder.name,
+                    sortOrder: folder.sortOrder,
+                    isExpanded: folder.isExpanded
+                )
+            }
         )
 
         PersistenceService.save(snapshot: snapshot)
@@ -362,7 +496,27 @@ class AppViewModel {
     private func loadFromDisk() {
         guard let snapshot = PersistenceService.load() else { return }
         environments = snapshot.environments.map { envSnapshot in
-            Environment(id: envSnapshot.id, name: envSnapshot.name, sortOrder: envSnapshot.sortOrder)
+            Environment(
+                id: envSnapshot.id,
+                name: envSnapshot.name,
+                sortOrder: envSnapshot.sortOrder,
+                folderID: envSnapshot.folderID,
+                isStarred: envSnapshot.isStarred ?? false
+            )
+        }
+        folders = (snapshot.folders ?? []).map { folderSnapshot in
+            Folder(
+                id: folderSnapshot.id,
+                name: folderSnapshot.name,
+                sortOrder: folderSnapshot.sortOrder,
+                isExpanded: folderSnapshot.isExpanded
+            )
+        }
+        // Drop dangling folder references so an environment whose folder no
+        // longer exists reappears at the top level instead of vanishing.
+        let folderIDs = Set(folders.map(\.id))
+        for env in environments where env.folderID != nil && !folderIDs.contains(env.folderID!) {
+            env.folderID = nil
         }
         selectedEnvironmentID = snapshot.selectedEnvironmentID
         fontSize = CGFloat(snapshot.fontSize)

--- a/CodeStationTests/AppViewModelTests.swift
+++ b/CodeStationTests/AppViewModelTests.swift
@@ -606,4 +606,147 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(sortedAfter.count, 3)
         XCTAssertEqual(sortedAfter[0].name, "C")
     }
+
+    // MARK: - Starring
+
+    func testToggleStar() {
+        let vm = makeSUT()
+        let env = vm.environments.first!
+        XCTAssertFalse(env.isStarred)
+        vm.toggleStar(env)
+        XCTAssertTrue(env.isStarred)
+        vm.toggleStar(env)
+        XCTAssertFalse(env.isStarred)
+    }
+
+    // MARK: - Folders
+
+    private func cleanFolders(_ vm: AppViewModel) {
+        for folder in vm.folders {
+            vm.removeFolder(folder)
+        }
+    }
+
+    func testAddFolder() {
+        let vm = makeSUT()
+        cleanFolders(vm)
+        let folder = vm.addFolder(name: "Work")
+        XCTAssertTrue(vm.folders.contains { $0.id == folder.id })
+        XCTAssertEqual(folder.name, "Work")
+        XCTAssertTrue(folder.isExpanded)
+    }
+
+    func testAddFolderDefaultName() {
+        let vm = makeSUT()
+        cleanFolders(vm)
+        let folder = vm.addFolder()
+        XCTAssertEqual(folder.name, Strings.Environments.newFolderName(1))
+    }
+
+    func testMoveEnvironmentIntoFolder() {
+        let vm = makeSUT()
+        cleanFolders(vm)
+        let env = vm.environments.first!
+        let folder = vm.addFolder(name: "Group")
+
+        vm.moveEnvironment(env, toFolder: folder.id)
+
+        XCTAssertEqual(env.folderID, folder.id)
+        XCTAssertTrue(vm.environments(in: folder).contains { $0.id == env.id })
+        XCTAssertFalse(vm.topLevelEnvironments.contains { $0.id == env.id })
+    }
+
+    func testMoveEnvironmentOutOfFolder() {
+        let vm = makeSUT()
+        cleanFolders(vm)
+        let env = vm.environments.first!
+        let folder = vm.addFolder(name: "Group")
+        vm.moveEnvironment(env, toFolder: folder.id)
+
+        vm.moveEnvironment(env, toFolder: nil)
+
+        XCTAssertNil(env.folderID)
+        XCTAssertTrue(vm.topLevelEnvironments.contains { $0.id == env.id })
+        XCTAssertTrue(vm.environments(in: folder).isEmpty)
+    }
+
+    func testRemoveFolderKeepsEnvironmentsAtTopLevel() {
+        let vm = makeSUT()
+        cleanFolders(vm)
+        let env = vm.environments.first!
+        let folder = vm.addFolder(name: "Group")
+        vm.moveEnvironment(env, toFolder: folder.id)
+
+        vm.removeFolder(folder)
+
+        XCTAssertFalse(vm.folders.contains { $0.id == folder.id })
+        XCTAssertNil(env.folderID)
+        XCTAssertTrue(vm.topLevelEnvironments.contains { $0.id == env.id })
+    }
+
+    func testSetFolderExpanded() {
+        let vm = makeSUT()
+        cleanFolders(vm)
+        let folder = vm.addFolder(name: "Group")
+        vm.setFolderExpanded(folder, expanded: false)
+        XCTAssertFalse(folder.isExpanded)
+        vm.setFolderExpanded(folder, expanded: true)
+        XCTAssertTrue(folder.isExpanded)
+    }
+
+    func testMoveEnvironmentBeforeReorders() {
+        let vm = makeSUT()
+        cleanFolders(vm)
+        while vm.environments.count > 1 {
+            vm.removeEnvironment(vm.environments.last!)
+        }
+        vm.environments.first!.folderID = nil
+        let a = vm.environments.first!
+        let b = vm.addEnvironment(name: "B")
+        let c = vm.addEnvironment(name: "C")
+
+        // Put C before A within the top level.
+        vm.moveEnvironment(c, before: a)
+
+        let order = vm.topLevelEnvironments.map(\.id)
+        XCTAssertEqual(order, [c.id, a.id, b.id])
+    }
+
+    func testHandleEnvironmentDropIntoFolder() {
+        let vm = makeSUT()
+        cleanFolders(vm)
+        let env = vm.environments.first!
+        let folder = vm.addFolder(name: "Group")
+
+        let accepted = vm.handleEnvironmentDrop([env.id.uuidString], toFolder: folder.id)
+
+        XCTAssertTrue(accepted)
+        XCTAssertEqual(env.folderID, folder.id)
+    }
+
+    func testHandleEnvironmentDropRejectsUnknownID() {
+        let vm = makeSUT()
+        let accepted = vm.handleEnvironmentDrop(["not-a-uuid"], toFolder: nil)
+        XCTAssertFalse(accepted)
+    }
+
+    func testVisibleEnvironmentsSkipsCollapsedFolders() {
+        let vm = makeSUT()
+        cleanFolders(vm)
+        while vm.environments.count > 1 {
+            vm.removeEnvironment(vm.environments.last!)
+        }
+        let topLevel = vm.environments.first!
+        topLevel.folderID = nil
+        let inFolder = vm.addEnvironment(name: "Inner")
+        let folder = vm.addFolder(name: "Group")
+        vm.moveEnvironment(inFolder, toFolder: folder.id)
+
+        vm.setFolderExpanded(folder, expanded: true)
+        XCTAssertTrue(vm.visibleEnvironmentsInOrder.contains { $0.id == inFolder.id })
+
+        vm.setFolderExpanded(folder, expanded: false)
+        XCTAssertFalse(vm.visibleEnvironmentsInOrder.contains { $0.id == inFolder.id })
+        XCTAssertTrue(vm.visibleEnvironmentsInOrder.contains { $0.id == topLevel.id })
+    }
 }

--- a/CodeStationTests/FolderTests.swift
+++ b/CodeStationTests/FolderTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import CodeStation
+
+final class FolderTests: XCTestCase {
+
+    // MARK: - Init
+
+    func testDefaultInit() {
+        let folder = Folder(name: "Work", sortOrder: 0)
+        XCTAssertEqual(folder.name, "Work")
+        XCTAssertEqual(folder.sortOrder, 0)
+        XCTAssertTrue(folder.isExpanded)
+        XCTAssertNotNil(folder.id)
+    }
+
+    func testInitWithCustomID() {
+        let customID = UUID()
+        let folder = Folder(id: customID, name: "Custom", sortOrder: 3, isExpanded: false)
+        XCTAssertEqual(folder.id, customID)
+        XCTAssertEqual(folder.name, "Custom")
+        XCTAssertEqual(folder.sortOrder, 3)
+        XCTAssertFalse(folder.isExpanded)
+    }
+
+    // MARK: - Identifiable
+
+    func testUniqueIDs() {
+        let a = Folder(name: "A", sortOrder: 0)
+        let b = Folder(name: "B", sortOrder: 1)
+        XCTAssertNotEqual(a.id, b.id)
+    }
+
+    // MARK: - Mutable Properties
+
+    func testNameCanBeChanged() {
+        let folder = Folder(name: "Original", sortOrder: 0)
+        folder.name = "Renamed"
+        XCTAssertEqual(folder.name, "Renamed")
+    }
+
+    func testExpandedCanBeToggled() {
+        let folder = Folder(name: "F", sortOrder: 0)
+        folder.isExpanded = false
+        XCTAssertFalse(folder.isExpanded)
+    }
+}

--- a/CodeStationTests/PersistenceModelsTests.swift
+++ b/CodeStationTests/PersistenceModelsTests.swift
@@ -136,6 +136,78 @@ final class PersistenceModelsTests: XCTestCase {
         XCTAssertNil(decoded.skipCloseConfirmation)
     }
 
+    // MARK: - Folders & Starring
+
+    func testFolderSnapshotEncodeDecode() throws {
+        let id = UUID()
+        let snapshot = FolderSnapshot(id: id, name: "Work", sortOrder: 2, isExpanded: false)
+        let data = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(FolderSnapshot.self, from: data)
+        XCTAssertEqual(decoded.id, id)
+        XCTAssertEqual(decoded.name, "Work")
+        XCTAssertEqual(decoded.sortOrder, 2)
+        XCTAssertFalse(decoded.isExpanded)
+    }
+
+    func testEnvironmentSnapshotPreservesFolderAndStar() throws {
+        let folderID = UUID()
+        let envSnapshot = EnvironmentSnapshot(
+            id: UUID(),
+            name: "Dev",
+            sortOrder: 0,
+            sessions: [],
+            columnProportions: [],
+            rowProportion: 0.5,
+            folderID: folderID,
+            isStarred: true
+        )
+        let data = try JSONEncoder().encode(envSnapshot)
+        let decoded = try JSONDecoder().decode(EnvironmentSnapshot.self, from: data)
+        XCTAssertEqual(decoded.folderID, folderID)
+        XCTAssertEqual(decoded.isStarred, true)
+    }
+
+    func testEnvironmentSnapshotDefaultsFolderAndStarNil() throws {
+        let envSnapshot = EnvironmentSnapshot(
+            id: UUID(),
+            name: "Dev",
+            sortOrder: 0,
+            sessions: [],
+            columnProportions: [],
+            rowProportion: 0.5
+        )
+        XCTAssertNil(envSnapshot.folderID)
+        XCTAssertNil(envSnapshot.isStarred)
+    }
+
+    func testLegacyEnvironmentSnapshotDecodesWithoutFolderFields() throws {
+        // A snapshot saved before folders/starring existed has neither key.
+        let json = """
+        {"id":"\(UUID().uuidString)","name":"Old","sortOrder":0,"sessions":[],"columnProportions":[],"rowProportion":0.5}
+        """
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(EnvironmentSnapshot.self, from: data)
+        XCTAssertNil(decoded.folderID)
+        XCTAssertNil(decoded.isStarred)
+    }
+
+    func testStoreSnapshotPreservesFolders() throws {
+        let folderID = UUID()
+        let snapshot = StoreSnapshot(
+            environments: [],
+            selectedEnvironmentID: nil,
+            fontSize: 13.0,
+            notificationSettings: nil,
+            promptButtons: nil,
+            skipCloseConfirmation: nil,
+            folders: [FolderSnapshot(id: folderID, name: "Group", sortOrder: 0, isExpanded: true)]
+        )
+        let data = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(StoreSnapshot.self, from: data)
+        XCTAssertEqual(decoded.folders?.count, 1)
+        XCTAssertEqual(decoded.folders?.first?.id, folderID)
+    }
+
     func testStoreSnapshotPreservesEnvironmentID() throws {
         let id = UUID()
         let snapshot = StoreSnapshot(

--- a/CodeStationTests/SidebarRowViewSnapshotTests.swift
+++ b/CodeStationTests/SidebarRowViewSnapshotTests.swift
@@ -36,6 +36,16 @@ final class SidebarRowViewSnapshotTests: XCTestCase {
         assertSnapshot(of: controller, as: .image)
     }
 
+    func testStarredRow() {
+        let viewModel = makeViewModel()
+        let env = viewModel.sortedEnvironments.first!
+        viewModel.toggleStar(env)
+        let view = SidebarRowView(environment: env, viewModel: viewModel)
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 220, height: 30)
+        assertSnapshot(of: controller, as: .image)
+    }
+
     func testRowWithNotificationBadge() {
         let viewModel = makeViewModel()
         let env = viewModel.sortedEnvironments.first!


### PR DESCRIPTION
## Summary
Adds two environment-management features to the sidebar:

1. **Folders** – group environments into collapsible/expandable folders (one level deep). Environments can be dragged into a folder or out to the top level, and a folder can be dragged to reorder among folders. Deleting a folder keeps its environments (they return to the top level).
2. **Starring** – an environment can be starred/unstarred from its context menu; a starred environment shows a filled star in place of the grid icon. Icon-only, as requested (no reordering side effect).

The bottom sidebar button is now a **`+` menu** offering *New Environment* / *New Folder*, each prompting for a name.

## Implementation
- **Model**: new `Folder` (`id`, `name`, `sortOrder`, `isExpanded`); `Environment` gains `folderID: UUID?` and `isStarred: Bool`.
- **Persistence**: new `FolderSnapshot`; optional `folderID`/`isStarred` on `EnvironmentSnapshot` and optional `folders` on `StoreSnapshot` (backward compatible with pre-folder saves). Dangling folder references are dropped on load so an environment never disappears.
- **AppViewModel**: `sortedFolders`, `topLevelEnvironments`, `environments(in:)`, `visibleEnvironmentsInOrder` (drives keyboard env navigation, skipping collapsed folders), plus folder CRUD, `toggleStar`, and drag/drop move helpers.
- **Sidebar**: folders as `DisclosureGroup`s with nested env rows; `.draggable`/`.dropDestination` for in/out moves; star icon swap; `+` menu.

## Tests
- New unit tests: `FolderTests`, folder/star/drag + visible-order tests in `AppViewModelTests`, and folder/star + legacy-decode round-trips in `PersistenceModelsTests`. All pass.
- Added a `testStarredRow` snapshot test.

## Pre-existing failures (NOT introduced by this PR — verified on `main`)
- **11 `AppViewModelTests`** (focus/terminal tests) fail on this machine because the suite instantiates `AppViewModel()`, which loads the real on-disk persistence file (this machine has 12 saved environments) instead of an isolated store. Identical failures occur on `main`.
- **All snapshot tests** fail on this machine — the reference images were recorded on a different machine/OS (unrelated `TerminalHeaderViewSnapshotTests` etc. fail on `main` too). The `SidebarView` snapshots legitimately change here (new `+` menu) and the new `testStarredRow` needs a reference; **both should be re-recorded in the same environment the existing snapshots were recorded in.**

## Not automated
Drag-and-drop and collapse/expand are interactive; verified the app builds and launches cleanly with real data. Manual UI verification of drag/drop still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
